### PR TITLE
Fix calendar by adding OAuth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .env
 *.log
 __pycache__
+token.pickle
+credentials.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN apk upgrade --update --no-cache \
     && rm /tmp/s6overlay.tar.gz
 
 
-
+WORKDIR /app
+COPY credentials.json /app/credentials.json
+COPY token.pickle /app/token.pickle
 COPY src/requirements.txt /requirements.txt
 RUN \
     apk add --no-cache --virtual=build-dependencies \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.8'
 
 services:
-  sesh-bot:
+  session_bot:
     build: .
     env_file: .env
     logging:

--- a/src/bot.py
+++ b/src/bot.py
@@ -91,7 +91,7 @@ async def send_long_announcement(session):
         embed.set_author(name=session.speaker)
     embed.set_footer(text=session.url)
     embed.set_image(url=IMG_URL)
-    await events_channel.send(f'Hey {fellow_role.mention}s and {ttp_fellow_role.mention} - we have session in 15 minutes! :tada:\n ({str(session.start.strftime("%H:%M GMT"))})', embed=embed)
+    await events_channel.send(f'Hey {fellow_role.mention}s and {ttp_fellow_role.mention}s - We have a session in 15 minutes! :tada:\n ({str(session.start.strftime("%H:%M GMT"))})', embed=embed)
 
 async def send_short_announcement(session):
     global events_channel, fellow_role, ttp_fellow_role

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,3 +2,6 @@ discord
 python-dotenv
 requests
 dateutils
+google-api-python-client 
+google-auth-httplib2 
+google-auth-oauthlib

--- a/src/schedule/cal.py
+++ b/src/schedule/cal.py
@@ -1,27 +1,50 @@
+from __future__ import print_function
 import requests
-import pytz
 import os
 import json
 import datetime
 import dateutil.parser
 from schedule.session import Session
 from dotenv import load_dotenv
+import datetime
+import pickle
+import os.path
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
 def get_calendar():
     load_dotenv()
-    r = requests.get(
-        f'https://www.googleapis.com/calendar/v3/calendars/{os.getenv("GCAL_ID")}/events?key={os.getenv("GCAL_KEY")}'
-    )
-    return r.json()
+    SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
+
+    creds = None
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('calendar', 'v3', credentials=creds)
+    now = datetime.datetime.utcnow().isoformat() + 'Z'  # 'Z' indicates UTC time
+    events_result = service.events().list(calendarId=os.getenv("GCAL_ID"), timeMin=now,
+                                          maxResults=1, singleEvents=True,
+                                          orderBy='startTime').execute()
+    events = events_result.get('items', [])
+    return events
 
 def get_next_session():
     now = datetime.datetime.now()
     cal_session = Session()
-
     try:
-        sessions = get_calendar()['items']
-        sorted_sessions = sort_calendar(sessions)
-        next_session = sorted_sessions[0]
+        sessions = get_calendar()
+        next_session = sessions[0]
         
         try:
             cal_session.start = dateutil.parser.parse(
@@ -38,24 +61,6 @@ def get_next_session():
         print("Cannot fetch events from calendar/malformed response")
 
     return cal_session
-            
-def sort_calendar(sessions):
-    utc = pytz.UTC
-    now = datetime.datetime.now()
-
-    # Remove cancelled events
-    sessions = [
-        session for session in sessions if session['status'] == "confirmed"]
-
-    # Sort events in chronological order 
-    sorted_sessions = sorted(
-        sessions, key=lambda x: dateutil.parser.parse(x['start']['dateTime']))
-    for session in sessions:
-        start = dateutil.parser.parse(session['start']['dateTime'])
-        if start.replace(tzinfo=utc) < now.replace(tzinfo=utc):
-            sorted_sessions.remove(session)
-
-    return sorted_sessions
 
 def get_title(description, summary, url):
     question1 = 'What is the title of this session?: '

--- a/src/schedule/cal.py
+++ b/src/schedule/cal.py
@@ -18,17 +18,17 @@ def get_calendar():
     SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
 
     creds = None
-    if os.path.exists('token.pickle'):
-        with open('token.pickle', 'rb') as token:
+    if os.path.exists('/app/token.pickle'):
+        with open('/app/token.pickle', 'rb') as token:
             creds = pickle.load(token)
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
-                'credentials.json', SCOPES)
+                '/app/credentials.json', SCOPES)
             creds = flow.run_local_server(port=0)
-        with open('token.pickle', 'wb') as token:
+        with open('/app/token.pickle', 'wb') as token:
             pickle.dump(creds, token)
 
     service = build('calendar', 'v3', credentials=creds)


### PR DESCRIPTION
Using a GET request was returning a 401 all of a sudden with no explanation. Looking at the documentation, this didn't seem to be a change to the API. Regardless, I've implemented a fix by using OAuth through `will.russell@majorleaguehacking.com`.

A `token.pickle` and `credientials.json` will now be requiered. This will be set up on the VM using existing ones generated.

## Changes
- Remove use of RESTful API
- Add Google Calendar Client Library
- Remove sort method as calendar will only get 1 event now.